### PR TITLE
Bumping electron

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     },
     "devDependencies": {
         "browser-monads": "^1.0.0",
-        "electron": "^9.1.1",
+        "electron": "^16.0.6",
         "electron-builder": "^20.40.2",
         "prettier": "^1.16.4"
     },


### PR DESCRIPTION
Hi,

I think this is the minimal change to take care of the electron update. I tried building the `gatsby develop` bundle and it looked OK to me. If someone could take a closer look and maybe merge this change that would be great. I'll poke around for any related updates.

-Ian